### PR TITLE
wga loadBalancerClass implementation

### DIFF
--- a/examples/lbc.yaml
+++ b/examples/lbc.yaml
@@ -18,7 +18,23 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: nginx-service
+  name: nginx-service-static
+  annotations:
+    wga.kraudcloud.com/loadBalancerIPs: 192.168.1.12,192.168.1.16
+spec:
+  type: LoadBalancer
+  loadBalancerClass: "wga.kraudcloud.com/intranet"
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service-dynamic
 spec:
   type: LoadBalancer
   loadBalancerClass: "wga.kraudcloud.com/intranet"

--- a/examples/lbc.yaml
+++ b/examples/lbc.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nginx-pod
+  labels:
+    app: nginx
+spec:
+  containers:
+    - name: nginx
+      image: nginx:latest
+      ports:
+        - containerPort: 80
+      resources:
+        limits:
+          cpu: "0.2"
+          memory: "128Mi"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nginx-service
+spec:
+  type: LoadBalancer
+  loadBalancerClass: "wga.kraudcloud.com/intranet"
+  selector:
+    app: nginx
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 80

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ func main() {
 		Short: "run named WireguardAccessEndpoint",
 		Run: func(cmd *cobra.Command, args []string) {
 			clientCIDRstr := os.Getenv("WGA_CLIENT_CIDR")
-			_, clientCIDR, err := net.ParseCIDR(clientCIDRstr)
+			_, peersNet, err := net.ParseCIDR(clientCIDRstr)
 			if err != nil {
 				slog.Error("cannot parse client cidr", "WGA_CLIENT_CIDR", clientCIDRstr, "err", err.Error())
 				os.Exit(1)
@@ -57,16 +57,16 @@ func main() {
 			}
 
 			allowedIPs := strings.Split(allowedIPEnv, ",")
-			allowedIPNets := []net.IPNet{}
+			serviceNets := []net.IPNet{}
 			for _, ip := range allowedIPs {
 				_, ipnet, err := net.ParseCIDR(ip)
 				if err != nil {
 					slog.Error("cannot parse allowed ip", "allowedIP", ip, "err", err.Error())
 				}
-				allowedIPNets = append(allowedIPNets, *ipnet)
+				serviceNets = append(serviceNets, *ipnet)
 			}
 
-			operator.RunWGA(cmd.Context(), clientConfig(), allowedIPNets, []net.IPNet{*clientCIDR}, serverAddr)
+			operator.RunWGA(cmd.Context(), clientConfig(), serviceNets, []net.IPNet{*peersNet}, serverAddr)
 		},
 	}
 	rootCmd.AddCommand(serverCmd)

--- a/operator/lbc.go
+++ b/operator/lbc.go
@@ -1,0 +1,137 @@
+package operator
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+
+	"github.com/apparentlymart/go-cidr/cidr"
+	corev1 "k8s.io/api/core/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	// LoadBalancerClass allows us to have wga assign ips to pods that currently do not have one.
+	// It avoids having the user set up a complicated mess of cillium/kubevip/metallb just for providing ips
+	// to services in the intranet.
+	LoadBalancerClass = "wga.kraudcloud.com/intranet"
+)
+
+var lbcPredicate = &predicate.TypedFuncs[client.Object]{
+	UpdateFunc: func(e event.UpdateEvent) bool {
+		s, ok := e.ObjectNew.(*corev1.Service)
+		if !ok {
+			return false
+		}
+
+		return isLoadBalancerClass(s) && hasNoIP(s)
+	},
+	CreateFunc: func(e event.CreateEvent) bool {
+		s, ok := e.Object.(*corev1.Service)
+		if !ok {
+			return false
+		}
+
+		return isLoadBalancerClass(s) && hasNoIP(s)
+	},
+	DeleteFunc: func(e event.DeleteEvent) bool {
+		s, ok := e.Object.(*corev1.Service)
+		if !ok {
+			return false
+		}
+
+		return isLoadBalancerClass(s) && hasNoIP(s)
+	},
+	GenericFunc: func(e event.GenericEvent) bool {
+		s, ok := e.Object.(*corev1.Service)
+		if !ok {
+			return false
+		}
+
+		return isLoadBalancerClass(s) && hasNoIP(s)
+	},
+}
+
+func isLoadBalancerClass(service *corev1.Service) bool {
+	return service != nil &&
+		service.Spec.LoadBalancerClass != nil &&
+		*service.Spec.LoadBalancerClass == LoadBalancerClass &&
+		service.Spec.Type == corev1.ServiceTypeLoadBalancer
+}
+
+func hasNoIP(service *corev1.Service) bool {
+	return service == nil || len(service.Status.LoadBalancer.Ingress) == 0 ||
+		service.Status.LoadBalancer.Ingress[0].IP == ""
+
+}
+
+func registerLoadBalancerReconciler(mgr ctrl.Manager, serviceNets []net.IPNet, log *slog.Logger) {
+	err := ctrl.NewControllerManagedBy(mgr).
+		For(&corev1.Service{}).
+		WithEventFilter(lbcPredicate).
+		Owns(&corev1.Service{}, builder.WithPredicates(lbcPredicate)).
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, o client.Object) []reconcile.Request {
+			return []reconcile.Request{{NamespacedName: client.ObjectKeyFromObject(o)}}
+		}), builder.WithPredicates(lbcPredicate)).
+		Complete(reconcile.AsReconciler(mgr.GetClient(), &LoadBalancerClassReconciler{
+			client:      mgr.GetClient(),
+			serviceNets: serviceNets,
+			log:         log.With("component", "service-controller"),
+		}))
+	if err != nil {
+		slog.Error("unable to create service-controller", "err", err)
+		os.Exit(1)
+	}
+}
+
+type LoadBalancerClassReconciler struct {
+	client      client.Client
+	serviceNets []net.IPNet
+	log         *slog.Logger
+}
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+// Compare the state specified by the LokiStack object against the actual cluster state,
+// and then perform operations to make the cluster state reflect the state specified by
+// the user.
+//
+// For more details, check Reconcile and its Result here:
+// - https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.18.2/pkg/reconcile
+func (r *LoadBalancerClassReconciler) Reconcile(ctx context.Context, svc *corev1.Service) (reconcile.Result, error) {
+	// We know we need to assign an ip.
+	if len(svc.Status.LoadBalancer.Ingress) != 0 {
+		return reconcile.Result{}, reconcile.TerminalError(fmt.Errorf("service already has an ip"))
+	}
+
+	r.log.Info("assigning ip to service", "service", svc.Name)
+
+	ip := net.ParseIP(svc.Spec.LoadBalancerIP)
+	var err error
+	// if the user didn't specify an ip, allocate one
+	if ip == nil {
+		// pick a random net
+		net := randPick(r.serviceNets)
+		// allocate a rand ip in that net
+		ip, err = cidr.HostBig(&net, generateIndex(&net))
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("unable to allocate ip: %w", err)
+		}
+	}
+
+	svc.Status.LoadBalancer.Ingress = []corev1.LoadBalancerIngress{{IP: ip.String()}}
+	err = r.client.Status().Update(ctx, svc)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("unable to update service status: %w", err)
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/operator/wga.go
+++ b/operator/wga.go
@@ -58,6 +58,7 @@ func RunWGA(ctx context.Context, config *rest.Config, servicesNet []net.IPNet, p
 
 	log.SetLogger(logr.FromSlogHandler(slog.With("component", "wga-controller").Handler()))
 
+	registerLoadBalancerReconciler(mgr, servicesNet, slog.Default())
 	registerPeerReconciler(mgr, servicesNet, peersNet, serverAddr, slog.Default())
 
 	if err = mgr.AddHealthzCheck("health", healthz.Ping); err != nil {

--- a/operator/wga.go
+++ b/operator/wga.go
@@ -49,7 +49,7 @@ func init() {
 	v1beta.SchemeBuilder.AddToScheme(scheme.Scheme)
 }
 
-func RunWGA(ctx context.Context, config *rest.Config, servicesNet []net.IPNet, peersNet []net.IPNet, serverAddr string) {
+func RunWGA(ctx context.Context, config *rest.Config, serviceNets []net.IPNet, peerNets []net.IPNet, serverAddr string) {
 	mgr, err := manager.New(config, manager.Options{})
 	if err != nil {
 		slog.Error("unable to create new manager", "err", err)
@@ -58,8 +58,8 @@ func RunWGA(ctx context.Context, config *rest.Config, servicesNet []net.IPNet, p
 
 	log.SetLogger(logr.FromSlogHandler(slog.With("component", "wga-controller").Handler()))
 
-	registerLoadBalancerReconciler(mgr, servicesNet, slog.Default())
-	registerPeerReconciler(mgr, servicesNet, peersNet, serverAddr, slog.Default())
+	registerLoadBalancerReconciler(mgr, serviceNets, slog.Default())
+	registerPeerReconciler(mgr, serviceNets, peerNets, serverAddr, slog.Default())
 
 	if err = mgr.AddHealthzCheck("health", healthz.Ping); err != nil {
 		slog.Error("unable to set up health check", "err", err)


### PR DESCRIPTION
implement loadbalancerclass `wga.kraudcloud.com/intranet` to allow wga to allocate intranet available ips, instead of having to rely on other lbc providers for allocating ips.

It currently selects the first net of the `allowedIPs` block in the configuration.

We might want to evolve that configuration setting use `WireguardAccessRule` (which we could rename), and have a default pool and possibly select pools. This makes the roles stuff on peers even more useful, and removes the static configuration dependency on `WGA_ALLOWED_IPS`.

TODO:
- [ ] Document that the first `allowedIPs` net is selected for the services
- [ ] Document the LoadBalancerClass name and annotations